### PR TITLE
DTSPO-15909 - migrated Application Insights

### DIFF
--- a/application-insights.tf
+++ b/application-insights.tf
@@ -1,45 +1,42 @@
-locals {
-  appinsights_name = "${var.product}-${var.env}"
-}
+module "application_insights" {
+  source = "git@github.com:hmcts/terraform-module-application-insights?ref=main"
 
-resource "azurerm_application_insights" "appinsights" {
-  name                = local.appinsights_name
+  env     = var.env
+  product = var.product
+
   location            = var.appinsights_location
-  resource_group_name = azurerm_resource_group.rg.name
   application_type    = var.appinsights_application_type
-  tags                = var.common_tags
+  resource_group_name = azurerm_resource_group.rg.name
 
-  lifecycle {
-    ignore_changes = [
-      # Ignore changes to appinsights as otherwise upgrading to the Azure provider 2.x
-      # destroys and re-creates this appinsights instance
-      application_type,
-    ]
-  }
+  common_tags = var.common_tags
 }
 
+moved {
+  from = azurerm_application_insights.appinsights
+  to   = module.application_insights.azurerm_application_insights.this
+}
 output "appInsightsName" {
-  value = local.appinsights_name
+  value = module.application_insights.name
 }
 
 output "appInsightsInstrumentationKey" {
   sensitive = true
-  value = azurerm_application_insights.appinsights.instrumentation_key
+  value     = module.application_insights.instrumentation_key
 }
 
 resource "azurerm_key_vault_secret" "app_insights_connection_string" {
   name         = "app-insights-connection-string"
-  value        = azurerm_application_insights.appinsights.connection_string
+  value        = module.application_insights.connection_string
   key_vault_id = module.wa_key_vault.key_vault_id
   content_type = "terraform-managed"
-  tags = var.common_tags
+  tags         = var.common_tags
 }
 
 resource "azurerm_key_vault_secret" "AZURE_APPINSGHTS_KEY" {
   name         = "AppInsightsInstrumentationKey"
-  value        = azurerm_application_insights.appinsights.instrumentation_key
+  value        = module.application_insights.instrumentation_key
   key_vault_id = module.wa_key_vault.key_vault_id
   content_type = "terraform-managed"
-  tags = var.common_tags
+  tags         = var.common_tags
 }
 


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-15909

### Change description ###
Updating azurerm_application_insights resource and replacing it with module terraform-module-application-insights

This will allow us to migrate Classic Application Insights using https://github.com/hmcts/app-insights-migration-tool as Classic Application Insights will deprecated and will be retired in February 2024.