### PR TITLE
RWA-3193 Add new alert when initiation or reconfiguration fails becau…

### DIFF
--- a/alerts.tf
+++ b/alerts.tf
@@ -169,3 +169,24 @@ module "wa-message-readiness-check-failure-alert" {
   enabled                    = true
   common_tags                = var.common_tags
 }
+
+module "wa-task-mandatory-field-missing-alert" {
+  source   = "git@github.com:hmcts/cnp-module-metric-alert"
+  location = var.location
+
+  app_insights_name = "wa-${var.env}"
+
+  alert_name           = "wa-task-mandatory-field-missing-alert"
+  alert_desc           = "Alert when mandatory fields are missing and task fails to initiate or reconfigure for case id"
+  app_insights_query   = "union traces | where message contains \"The following mandatory fields are missing from task:\" | sort by timestamp desc"
+  custom_email_subject = "Alert: Task mandatory fields are missing wa-${var.env}"
+  frequency_in_minutes = "60"
+  time_window_in_minutes     = "60"
+  severity_level             = "2"
+  action_group_name          = "wa-support" //TODO: Change this to appropriate service group once it is created
+  trigger_threshold_operator = "GreaterThan"
+  trigger_threshold          = "0"
+  resourcegroup_name         = azurerm_resource_group.rg.name
+  enabled                    = var.enable-wa-task-mandatory-field-missing-alert
+  common_tags                = var.common_tags
+}

--- a/alerts.tf
+++ b/alerts.tf
@@ -176,11 +176,11 @@ module "wa-task-mandatory-field-missing-alert" {
 
   app_insights_name = "wa-${var.env}"
 
-  alert_name           = "wa-task-mandatory-field-missing-alert"
-  alert_desc           = "Alert when mandatory fields are missing and task fails to initiate or reconfigure for case id"
-  app_insights_query   = "union traces | where message contains \"The following mandatory fields are missing from task:\" | sort by timestamp desc"
-  custom_email_subject = "Alert: Task mandatory fields are missing wa-${var.env}"
-  frequency_in_minutes = "60"
+  alert_name                 = "wa-task-mandatory-field-missing-alert"
+  alert_desc                 = "Alert when mandatory fields are missing and task fails to initiate or reconfigure for case id"
+  app_insights_query         = "union traces | where message contains \"The following mandatory fields are missing from task:\" | sort by timestamp desc"
+  custom_email_subject       = "Alert: Task mandatory fields are missing wa-${var.env}"
+  frequency_in_minutes       = "60"
   time_window_in_minutes     = "60"
   severity_level             = "2"
   action_group_name          = "wa-support" //TODO: Change this to appropriate service group once it is created

--- a/variables.tf
+++ b/variables.tf
@@ -84,3 +84,7 @@ variable "additional_managed_identities_access" {
   description = "The name of your application"
   default     = []
 }
+
+variable "enable-wa-task-mandatory-field-missing-alert" {
+  default = false
+}


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/RWA-3193

### Change description
Adding new alerts when initiation/reconfiguration fails because of missing mandatory fields in tasks

### Testing done


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
