### PR TITLE
Grant pcs managed identity access to wa-aat key vault

### DIFF
--- a/aat.tfvars
+++ b/aat.tfvars
@@ -1,3 +1,3 @@
 allowed_jurisdictions = "'wa', 'WA', 'ia', 'IA','civil', 'CIVIL', 'publiclaw', 'PUBLICLAW', 'privatelaw', 'PRIVATELAW','st_cic','ST_CIC','employment','EMPLOYMENT','sscs', 'SSCS','DIVORCE','divorce'"
 
-additional_managed_identities_access = ["et", "sptribs", "civil", "ia", "sscs", "fpl"]
+additional_managed_identities_access = ["et", "sptribs", "civil", "ia", "sscs", "fpl", "pcs"]


### PR DESCRIPTION
## Summary
- Adds `"pcs"` to `additional_managed_identities_access` in `aat.tfvars`, granting the PCS (possession-claims-service) managed identity `secrets get` on the `wa-aat` key vault.

